### PR TITLE
Resolve cyclic dependency by splitting PasswordEncoder config

### DIFF
--- a/planhub/src/main/java/com/planhub/config/EncoderConfig.java
+++ b/planhub/src/main/java/com/planhub/config/EncoderConfig.java
@@ -1,0 +1,14 @@
+package com.planhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class EncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/planhub/src/main/java/com/planhub/config/SecurityConfig.java
+++ b/planhub/src/main/java/com/planhub/config/SecurityConfig.java
@@ -5,10 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -17,10 +15,8 @@ public class SecurityConfig {
     @Autowired
     private UserService userService;
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Bean
     public UserDetailsService userDetailsService() {
@@ -30,7 +26,7 @@ public class SecurityConfig {
     @Bean
     public DaoAuthenticationProvider authProvider() {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setPasswordEncoder(passwordEncoder());
+        provider.setPasswordEncoder(passwordEncoder);
         provider.setUserDetailsService(userDetailsService());
         return provider;
     }


### PR DESCRIPTION
## Summary
- move PasswordEncoder bean to new `EncoderConfig`
- inject PasswordEncoder in `SecurityConfig` instead of defining its own bean

## Testing
- `mvn -q -f planhub/pom.xml test` *(fails: maven resources plugin could not be resolved due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887ca5568f4832cba275125c186d53d