### PR TITLE
Fix missing Thymeleaf layout fragment

### DIFF
--- a/planhub/src/main/resources/templates/dashboard.html
+++ b/planhub/src/main/resources/templates/dashboard.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div>
     <h2 class="text-2xl mb-4">Übersicht</h2>
     <div>

--- a/planhub/src/main/resources/templates/layout.html
+++ b/planhub/src/main/resources/templates/layout.html
@@ -15,6 +15,8 @@
         <a class="mx-2 hover:text-orange-500" th:href="@{/profile}">Profil</a>
     </nav>
 </header>
-<div class="container mx-auto p-4" th:replace="~{::content}"></div>
+<div class="container mx-auto p-4" th:fragment="content">
+    <main th:insert="~{::body}"></main>
+</div>
 </body>
 </html>

--- a/planhub/src/main/resources/templates/login.html
+++ b/planhub/src/main/resources/templates/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div class="max-w-sm mx-auto">
     <h2 class="text-2xl mb-4">Login</h2>
     <form method="post">

--- a/planhub/src/main/resources/templates/profile.html
+++ b/planhub/src/main/resources/templates/profile.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div class="max-w-sm mx-auto">
     <h2 class="text-2xl mb-4">Profil</h2>
     <p><strong>Email:</strong> <span th:text="${user.email}"></span></p>

--- a/planhub/src/main/resources/templates/projects/form.html
+++ b/planhub/src/main/resources/templates/projects/form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div class="max-w-sm mx-auto">
     <h2 class="text-2xl mb-4">Projekt</h2>
     <form method="post" th:object="${project}">

--- a/planhub/src/main/resources/templates/projects/list.html
+++ b/planhub/src/main/resources/templates/projects/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div>
     <div class="mb-4 text-right">
         <a class="bg-orange-500 px-4 py-2 rounded" th:href="@{/projects/new}">Neues Projekt</a>

--- a/planhub/src/main/resources/templates/register.html
+++ b/planhub/src/main/resources/templates/register.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div class="max-w-sm mx-auto">
     <h2 class="text-2xl mb-4">Registrieren</h2>
     <form method="post" th:object="${user}">

--- a/planhub/src/main/resources/templates/tasks/form.html
+++ b/planhub/src/main/resources/templates/tasks/form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div class="max-w-sm mx-auto">
     <h2 class="text-2xl mb-4">Aufgabe</h2>
     <form method="post" th:object="${task}">

--- a/planhub/src/main/resources/templates/tasks/list.html
+++ b/planhub/src/main/resources/templates/tasks/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: content">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: content}">
 <div>
     <div class="mb-4 text-right">
         <a class="bg-orange-500 px-4 py-2 rounded" th:href="@{/tasks/new}">Neue Aufgabe</a>


### PR DESCRIPTION
## Summary
- define `content` fragment in layout.html and use `th:insert` to include page bodies
- use modern `~{layout :: content}` syntax across templates

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact from https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6887cd5c3890832c9e85ec087b15ab83